### PR TITLE
Allow keyword arguments to Base.close

### DIFF
--- a/src/OpenTrick.jl
+++ b/src/OpenTrick.jl
@@ -58,9 +58,9 @@ end
 
 Close `io` and unblock the corresponding blocking task.
 """
-function Base.close(w::IOWrapper)
+function Base.close(w::IOWrapper; kwargs...)
     try
-        close(rawio(w))
+        close(rawio(w); kwargs...)
     catch e
         rethrow(e)
     finally

--- a/src/OpenTrick.jl
+++ b/src/OpenTrick.jl
@@ -54,7 +54,7 @@ function opentrick(open::Function, args...; kwargs...)
 end
 
 """
-    close(io)
+    close(io; kwargs...)
 
 Close `io` and unblock the corresponding blocking task.
 """


### PR DESCRIPTION
`WebSockets.close` has a couple of keyword arguments which I'd like to use :slightly_smiling_face: 